### PR TITLE
Use secure password generator in PDF controller

### DIFF
--- a/src/main/java/org/acentrik/controller/PdfController.java
+++ b/src/main/java/org/acentrik/controller/PdfController.java
@@ -20,6 +20,7 @@ import org.acentrik.model.User;
 import org.acentrik.service.EmailService;
 import org.acentrik.service.OfferLetterService;
 import org.acentrik.service.UserService;
+import org.acentrik.service.PasswordValidator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -46,6 +47,9 @@ public class PdfController {
 
     @Autowired
     private OfferLetterService offerLetterService;
+
+    @Autowired
+    private PasswordValidator passwordValidator;
 
     @PostMapping("/generatePdf")
     public void downloadPDF(@ModelAttribute FormData formData, HttpServletResponse response, jakarta.servlet.http.HttpSession session) throws java.io.IOException {
@@ -124,15 +128,7 @@ public class PdfController {
      * @return A random password
      */
     private String generateRandomPassword() {
-        // Generate a random password with 8 characters
-        String chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-        StringBuilder sb = new StringBuilder();
-        java.util.Random random = new java.util.Random();
-        for (int i = 0; i < 8; i++) {
-            int index = random.nextInt(chars.length());
-            sb.append(chars.charAt(index));
-        }
-        return sb.toString();
+        return passwordValidator.generateRandomPassword();
     }
     @PostMapping("/emailPdf")
     public String emailPDF(@ModelAttribute FormData formData, Model model) {

--- a/src/test/java/org/acentrik/controller/PdfControllerTest.java
+++ b/src/test/java/org/acentrik/controller/PdfControllerTest.java
@@ -1,0 +1,40 @@
+package org.acentrik.controller;
+
+import org.acentrik.service.PasswordValidator;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for {@link PdfController} password generation.
+ */
+public class PdfControllerTest {
+
+    /**
+     * Verify that the controller generates passwords that satisfy the
+     * complexity requirements enforced by {@link PasswordValidator}.
+     */
+    @Test
+    public void testGenerateRandomPasswordMeetsComplexity() throws Exception {
+        PdfController controller = new PdfController();
+        PasswordValidator validator = new PasswordValidator();
+
+        // Inject PasswordValidator into the controller
+        Field field = PdfController.class.getDeclaredField("passwordValidator");
+        field.setAccessible(true);
+        field.set(controller, validator);
+
+        // Invoke the private generateRandomPassword method
+        Method method = PdfController.class.getDeclaredMethod("generateRandomPassword");
+        method.setAccessible(true);
+        String password = (String) method.invoke(controller);
+
+        List<String> errors = validator.validatePasswordComplexity(password);
+        assertTrue(errors.isEmpty(), "Generated password should meet complexity requirements");
+    }
+}
+


### PR DESCRIPTION
## Summary
- Delegate password generation in `PdfController` to `PasswordValidator` so new user accounts receive complex passwords
- Add unit test ensuring generated passwords satisfy the configured complexity rules

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM ... network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_689e2c8491508323b071e191edd3af58