### PR TITLE
Allow server port override via environment variables

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.application.name=GeneratePDF
 
-server.port=8091
+server.port=${PORT:${SERVER_PORT:8091}}
 
 # Database configuration with fallback to H2 in-memory database
 spring.datasource.url=${SPRING_DATASOURCE_URL:jdbc:h2:mem:pdf}


### PR DESCRIPTION
## Summary
- allow Spring Boot server port to be configured with PORT or SERVER_PORT env vars

## Testing
- `./mvnw -q test` *(fails: wget: Failed to fetch https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.zip)*

------
https://chatgpt.com/codex/tasks/task_e_689e352f4d448323bdf96c826e94afb6